### PR TITLE
Add fraction of a second format string.

### DIFF
--- a/mygpoclient/util.py
+++ b/mygpoclient/util.py
@@ -28,12 +28,14 @@ def iso8601_to_datetime(s):
 
     >>> iso8601_to_datetime('2009-12-29T19:25:33')
     datetime.datetime(2009, 12, 29, 19, 25, 33)
+    >>> iso8601_to_datetime('2009-12-29T19:25:33.1')
+    datetime.datetime(2009, 12, 29, 19, 25, 33, 100000)
     >>> iso8601_to_datetime('2009-12-29T19:25:33Z')
     datetime.datetime(2009, 12, 29, 19, 25, 33)
     >>> iso8601_to_datetime('xXxXxXxXxxxxXxxxXxx')
     >>>
     """
-    for format in ('%Y-%m-%dT%H:%M:%S', '%Y-%m-%dT%H:%M:%SZ'):
+    for format in ('%Y-%m-%dT%H:%M:%S', '%Y-%m-%dT%H:%M:%S.%f', '%Y-%m-%dT%H:%M:%SZ'):
         try:
             return datetime.datetime.strptime(s, format)
         except ValueError:


### PR DESCRIPTION
ISO-8601 supports fraction of a second data and the API appears to return
data with fraction of a second granularity.

I've seen this error for a while now:

```
2016-10-29 13:30:55,543 [gpodder.my] WARNING: Exception while polling for episodes.
Traceback (most recent call last):
  File "<snip>\gpodder\gPodderPortable\App\gPodder\src\gpodder\my.py", line 496, in synchronize_episodes
    changes = self._client.download_episode_actions(since_o.since)
  File "<snip>\gpodder\gPodderPortable\App\gPodder\src\mygpoclient\simple.py", line 38, in _wrapper
    return f(self, *args, **kwargs)
  File "<snip>\gpodder\gPodderPortable\App\gPodder\src\mygpoclient\api.py", line 360, in download_episode_actions
    actions = [EpisodeAction.from_dictionary(d) for d in dicts]
  File "<snip>\gpodder\gPodderPortable\App\gPodder\src\mygpoclient\api.py", line 182, in from_dictionary
    d.get('started'), d.get('position'), d.get('total'))
  File "<snip>\gpodder\gPodderPortable\App\gPodder\src\mygpoclient\api.py", line 142, in __init__
    raise ValueError('Timestamp has to be in ISO 8601 format but was %s' % timestamp)
ValueError: Timestamp has to be in ISO 8601 format but was 2016-10-29T12:05:51.829000
```

This appears to resolve it.  I'm not sure if this is the best solution but my other thought was to use a helper library (e.g. [pendulum](https://pypi.python.org/pypi/pendulum)) and it didn't seem like adding a dependency was the best answer without some more context.
