### PR TITLE
Update issue tracker link

### DIFF
--- a/README
+++ b/README
@@ -26,10 +26,9 @@ the gPodder developers mailing list at
 
     gpodder@freelists.org
 
-You can report bugs and problems that you find by using our
-Bugzilla installation at
+You can report bugs and problems that you find on GitHub at
 
-    http://bugs.gpodder.org/
+    https://github.com/gpodder/gpodder/issues
 
 Thank you for your interest in the mygpoclient library!
 


### PR DESCRIPTION
Directs readers to the GitHub issue tracker rather than Bugzilla